### PR TITLE
Sprint 3: migrate Requests + Matches to MongoDB, and wire Discover invite

### DIFF
--- a/back-end/models/Request.js
+++ b/back-end/models/Request.js
@@ -1,0 +1,59 @@
+const mongoose = require('mongoose');
+const { randomUUID } = require('crypto');
+
+const REQUEST_STATUSES = ['pending', 'accepted', 'declined', 'cancelled'];
+
+const requestSchema = new mongoose.Schema(
+  {
+    _id: {
+      type: String,
+      default: () => randomUUID(),
+    },
+    fromUserId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    toUserId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    message: {
+      type: String,
+      default: '',
+      trim: true,
+      maxlength: 500,
+    },
+    status: {
+      type: String,
+      enum: REQUEST_STATUSES,
+      default: 'pending',
+      index: true,
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+    updatedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    versionKey: false,
+    collection: 'requests',
+  }
+);
+
+requestSchema.pre('save', function updateTimestamp() {
+  this.updatedAt = new Date();
+});
+
+requestSchema.index({ fromUserId: 1, toUserId: 1, status: 1 });
+
+module.exports = {
+  Request:
+    mongoose.models.Request || mongoose.model('Request', requestSchema),
+  REQUEST_STATUSES,
+};

--- a/back-end/routes/matches.js
+++ b/back-end/routes/matches.js
@@ -1,12 +1,13 @@
-// routes/matches.js — GET /api/matches
+// routes/matches.js — GET /api/matches (MongoDB-backed)
 const express = require('express');
 const router = express.Router();
-const mockUsers = require('../data/users');
+const User = require('../models/User');
+const { connectToDatabase } = require('../modules/db');
 const { calculateMatchScore } = require('../modules/matchScoring');
 const { calculateRankScore } = require('../modules/rankScoring');
 const { generateReasons } = require('../modules/matchReasons');
 
-router.get('/matches', (req, res) => {
+router.get('/matches', async (req, res) => {
   try {
     const currentUser = req.user;
 
@@ -16,11 +17,19 @@ router.get('/matches', (req, res) => {
       return res.json({ currentUserId: currentUser._id, matches: [] });
     }
 
+    await connectToDatabase();
+
+    // Pull every other user from Mongo (excluding the current user).
+    const candidates = await User.find({
+      _id: { $ne: currentUser._id },
+    }).lean();
+
     const matches = [];
 
-    for (const candidate of mockUsers) {
+    for (const candidate of candidates) {
       // Skip candidates who haven't completed onboarding
       if (!candidate.availability || candidate.role === null) continue;
+
       // Step a: Score
       const matchResult = calculateMatchScore(currentUser, candidate);
       if (!matchResult) continue;
@@ -34,7 +43,9 @@ router.get('/matches', (req, res) => {
 
       // Step d: Reasons
       const sharedGoals = generateReasons(
-        currentUser, candidate, matchResult.scoreBreakdown
+        currentUser,
+        candidate,
+        matchResult.scoreBreakdown
       );
 
       // Step e: Build response (explicit allowlist)
@@ -56,7 +67,7 @@ router.get('/matches', (req, res) => {
         feedbackStyle: candidate.feedbackStyle,
         sessionsCompleted: candidate.sessionsCompleted,
         showUpRate: candidate.showUpRate,
-        isNew: candidate.sessionsCompleted < 3,
+        isNew: (candidate.sessionsCompleted ?? 0) < 3,
         matchPercent: matchResult.matchPercent,
         sharedGoals,
         sharedCells: matchResult.sharedCells,
@@ -64,20 +75,25 @@ router.get('/matches', (req, res) => {
         inviteStatus: null,
         // Hidden — used for sorting only, stripped before response
         _rankScore: rankScore,
-        _createdAt: candidate.createdAt
+        _createdAt: candidate.createdAt,
       });
     }
 
     // Sort: rankScore desc → matchPercent desc → sharedCells desc → createdAt desc
     matches.sort((a, b) => {
       if (b._rankScore !== a._rankScore) return b._rankScore - a._rankScore;
-      if (b.matchPercent !== a.matchPercent) return b.matchPercent - a.matchPercent;
-      if (b.sharedCells !== a.sharedCells) return b.sharedCells - a.sharedCells;
+      if (b.matchPercent !== a.matchPercent)
+        return b.matchPercent - a.matchPercent;
+      if (b.sharedCells !== a.sharedCells)
+        return b.sharedCells - a.sharedCells;
       return new Date(b._createdAt) - new Date(a._createdAt);
     });
 
     // Strip hidden sort fields before sending
-    matches.forEach(m => { delete m._rankScore; delete m._createdAt; });
+    matches.forEach((m) => {
+      delete m._rankScore;
+      delete m._createdAt;
+    });
 
     res.json({ currentUserId: currentUser._id, matches });
   } catch (err) {

--- a/back-end/routes/requests.js
+++ b/back-end/routes/requests.js
@@ -1,89 +1,141 @@
 const express = require('express');
-const { body, validationResult } = require('express-validator');
-const { randomUUID } = require('crypto');
-const mockRequests = require('../data/mockRequests.json');
+const { body, param, validationResult } = require('express-validator');
+const { Request, REQUEST_STATUSES } = require('../models/Request');
+const { connectToDatabase } = require('../modules/db');
 
 const router = express.Router();
 
-const REQUEST_STATUS_OPTIONS = ['pending', 'accepted', 'declined', 'cancelled'];
-
 function validationErrors(req, res, next) {
   const result = validationResult(req);
-  if (result.isEmpty()) {
-    return next();
-  }
-
+  if (result.isEmpty()) return next();
   return res.status(400).json({
     error: 'Validation failed',
     details: result.array().map((item) => item.msg),
   });
 }
 
+function asyncHandler(handler) {
+  return (req, res, next) =>
+    Promise.resolve(handler(req, res, next)).catch(next);
+}
+
+function serializeRequest(doc) {
+  if (!doc) return null;
+  const plain = doc.toObject ? doc.toObject() : doc;
+  return {
+    id: plain._id,
+    fromUserId: plain.fromUserId,
+    toUserId: plain.toUserId,
+    message: plain.message || '',
+    status: plain.status,
+    createdAt:
+      plain.createdAt instanceof Date
+        ? plain.createdAt.toISOString()
+        : plain.createdAt,
+    updatedAt:
+      plain.updatedAt instanceof Date
+        ? plain.updatedAt.toISOString()
+        : plain.updatedAt,
+  };
+}
+
 const createValidators = [
-  body('fromUserId').notEmpty().withMessage('fromUserId is required.'),
-  body('toUserId').notEmpty().withMessage('toUserId is required.'),
+  body('fromUserId')
+    .isString()
+    .withMessage('fromUserId must be a string.')
+    .trim()
+    .notEmpty()
+    .withMessage('fromUserId is required.'),
+  body('toUserId')
+    .isString()
+    .withMessage('toUserId must be a string.')
+    .trim()
+    .notEmpty()
+    .withMessage('toUserId is required.'),
   body('message')
     .optional()
     .isString()
-    .withMessage('message must be a string.'),
+    .withMessage('message must be a string.')
+    .isLength({ max: 500 })
+    .withMessage('message must be 500 characters or less.'),
   validationErrors,
 ];
 
 const patchValidators = [
+  param('id').isString().notEmpty(),
   body('status')
-    .optional()
-    .isIn(REQUEST_STATUS_OPTIONS)
-    .withMessage(`status must be one of: ${REQUEST_STATUS_OPTIONS.join(', ')}`),
+    .isIn(REQUEST_STATUSES)
+    .withMessage(`status must be one of: ${REQUEST_STATUSES.join(', ')}`),
   validationErrors,
 ];
 
-router.get('/requests', (req, res) => {
-  return res.status(200).json({ requests: mockRequests });
-});
+router.get(
+  '/requests',
+  asyncHandler(async (req, res) => {
+    await connectToDatabase();
+    const list = await Request.find().sort({ updatedAt: -1 }).lean();
+    return res.status(200).json({
+      requests: list.map(serializeRequest),
+    });
+  })
+);
 
-router.get('/requests/:id', (req, res) => {
-  const request = mockRequests.find((candidate) => candidate.id === req.params.id);
+router.get(
+  '/requests/:id',
+  asyncHandler(async (req, res) => {
+    await connectToDatabase();
+    const doc = await Request.findById(req.params.id).lean();
+    if (!doc) return res.status(404).json({ error: 'Request not found' });
+    return res.status(200).json({ request: serializeRequest(doc) });
+  })
+);
 
-  if (!request) {
-    return res.status(404).json({ error: 'Request not found' });
-  }
+router.post(
+  '/requests',
+  createValidators,
+  asyncHandler(async (req, res) => {
+    await connectToDatabase();
 
-  return res.status(200).json({ request });
-});
+    const fromUserId = String(req.body.fromUserId).trim();
+    const toUserId = String(req.body.toUserId).trim();
 
-router.post('/requests', createValidators, (req, res) => {
-  const newRequest = {
-    id: randomUUID(),
-    fromUserId: req.body.fromUserId,
-    toUserId: req.body.toUserId,
-    message: req.body.message || '',
-    status: 'pending',
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-  };
+    if (fromUserId === toUserId) {
+      return res
+        .status(400)
+        .json({ error: 'Cannot send a request to yourself.' });
+    }
 
-  mockRequests.push(newRequest);
+    const created = await Request.create({
+      fromUserId,
+      toUserId,
+      message: req.body.message || '',
+      status: 'pending',
+    });
 
-  return res.status(201).json({ request: newRequest });
-});
+    return res.status(201).json({ request: serializeRequest(created) });
+  })
+);
 
-router.patch('/requests/:id', patchValidators, (req, res) => {
-  const requestIndex = mockRequests.findIndex((candidate) => candidate.id === req.params.id);
+router.patch(
+  '/requests/:id',
+  patchValidators,
+  asyncHandler(async (req, res) => {
+    await connectToDatabase();
 
-  if (requestIndex === -1) {
-    return res.status(404).json({ error: 'Request not found' });
-  }
+    const updated = await Request.findByIdAndUpdate(
+      req.params.id,
+      {
+        $set: {
+          status: req.body.status,
+          updatedAt: new Date(),
+        },
+      },
+      { new: true, runValidators: true }
+    ).lean();
 
-  const existingRequest = mockRequests[requestIndex];
-  const updatedRequest = {
-    ...existingRequest,
-    ...req.body,
-    updatedAt: new Date().toISOString(),
-  };
-
-  mockRequests[requestIndex] = updatedRequest;
-
-  return res.status(200).json({ request: updatedRequest });
-});
+    if (!updated) return res.status(404).json({ error: 'Request not found' });
+    return res.status(200).json({ request: serializeRequest(updated) });
+  })
+);
 
 module.exports = router;

--- a/front-end/src/pages/DiscoverPage.jsx
+++ b/front-end/src/pages/DiscoverPage.jsx
@@ -41,36 +41,33 @@ function DiscoverPage() {
     navigate(`/profile/${userId}`);
   }
 
-  async function handleSendInvite(userId) {
+    async function handleSendInvite(userId) {
     try {
-      const fromUserId =
-        localStorage.getItem("userId") || "current-user";
-      const res = await fetch(
-        `/api/requests?userId=${encodeURIComponent(fromUserId)}`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            fromUserId,
-            toUserId: userId,
-            message: "Want to practice this week?",
-          }),
-        }
-      );
+      const token = localStorage.getItem("token") || "";
 
-      const data = await res.json();
+      const res = await fetch("/api/friends/requests", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ toUserId: userId }),
+      });
+
+      const data = await res.json().catch(() => ({}));
 
       if (!res.ok) {
+        // 409 = already friends / already pending / reverse pending
+        // 401 = missing or expired token
+        // 400 = validation error
         throw new Error(data.error || "Failed to send invite");
       }
 
-      console.log("Invite created:", data);
+      console.log("Friend request created:", data);
 
       setUsers((prev) =>
         prev.map((user) =>
-          user.id === userId ? { ...user, invited: true } : user
+          user.userId === userId ? { ...user, invited: true } : user
         )
       );
     } catch (err) {

--- a/front-end/src/pages/DiscoverPage.jsx
+++ b/front-end/src/pages/DiscoverPage.jsx
@@ -67,7 +67,7 @@ function DiscoverPage() {
 
       setUsers((prev) =>
         prev.map((user) =>
-          user.userId === userId ? { ...user, invited: true } : user
+          user.userId === userId ? { ...user, inviteStatus: "sent" } : user
         )
       );
     } catch (err) {


### PR DESCRIPTION
On the backend, I replaced the mock JSON in routes/requests.js with real MongoDB queries using a new Mongoose model (models/Request.js), and added validation plus a guard against sending a request to yourself. I also migrated routes/matches.js to pull candidates from MongoDB instead of the mock users file. The scoring, ranking, and reasons logic is untouched, and the API response shape is the same as before.

On the frontend, I updated DiscoverPage so clicking Invite now sends a POST to /api/friends/requests with the user's JWT token, instead of hitting the old /api/requests endpoint. I also fixed a small bug where the Invite button never flipped to "Invite sent" after a successful click.

With these changes, the full friend-request flow works end to end: clicking Invite on Discover creates a pending request in MongoDB, it shows up in the sender's Waiting tab and the recipient's Received tab, accept/decline/cancel all work, and accepted requests appear in the Partners list.