### PR TITLE
Remove Remaining Mock Behaviors and Polish UI/UX Design

### DIFF
--- a/back-end/controllers/settingsController.js
+++ b/back-end/controllers/settingsController.js
@@ -106,60 +106,54 @@ const deleteAccount = async (req, res) => {
   res.status(200).json({ message: "Account deleted successfully" });
 };
 
-const getNotificationSettings = (req, res) => {
-  const { email } = req.query;
+const getNotificationSettings = async (req, res) => {
+  try {
+    const { email } = req.query;
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
 
-  const user = users.find((u) => u.email === email);
-  if (!user) {
-    return res.status(404).json({ message: "User not found" });
+    const n = user.notifications || {};
+    return res.status(200).json({
+      newInvitationReceived: n.newInvitationReceived ?? n.inviteReceived ?? true,
+      inviteAccepted: n.inviteAccepted ?? n.matchConfirmed ?? true,
+      sessionReminder: n.sessionReminder ?? true,
+      sessionBookingConfirmation: n.sessionBookingConfirmation ?? true,
+    });
+  } catch (_err) {
+    return res.status(500).json({ message: "Server error" });
   }
-
-  // Seed missing notifications block (covers legacy mock users)
-  if (!user.notifications) {
-    user.notifications = {
-      newInvitationReceived: true,
-      inviteAccepted: true,
-      sessionReminder: true,
-      sessionBookingConfirmation: true,
-    };
-  }
-
-  // The unified schema stores keys as { inviteReceived, matchConfirmed, sessionReminder }.
-  // The front-end SettingsPage expects { newInvitationReceived, inviteAccepted, sessionReminder, sessionBookingConfirmation }.
-  // Normalise outbound so both sides stay happy.
-  const n = user.notifications;
-  res.status(200).json({
-    newInvitationReceived: n.newInvitationReceived ?? n.inviteReceived ?? true,
-    inviteAccepted:        n.inviteAccepted        ?? n.matchConfirmed ?? true,
-    sessionReminder:       n.sessionReminder       ?? true,
-    sessionBookingConfirmation: n.sessionBookingConfirmation ?? true,
-  });
 };
 
-const updateNotificationSettings = (req, res) => {
-  const { email, notifications } = req.body;
+const updateNotificationSettings = async (req, res) => {
+  try {
+    const { email, notifications } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
 
-  const user = users.find((u) => u.email === email);
-  if (!user) {
-    return res.status(404).json({ message: "User not found" });
+    user.notifications = {
+      ...(user.notifications || {}),
+      ...(notifications || {}),
+    };
+    user.updatedAt = new Date();
+    await user.save();
+
+    const n = user.notifications;
+    return res.status(200).json({
+      message: "Notification settings updated successfully",
+      notifications: {
+        newInvitationReceived: n.newInvitationReceived ?? n.inviteReceived ?? true,
+        inviteAccepted: n.inviteAccepted ?? n.matchConfirmed ?? true,
+        sessionReminder: n.sessionReminder ?? true,
+        sessionBookingConfirmation: n.sessionBookingConfirmation ?? true,
+      },
+    });
+  } catch (_err) {
+    return res.status(500).json({ message: "Server error" });
   }
-
-  user.notifications = {
-    ...user.notifications,
-    ...notifications,
-  };
-  user.updatedAt = new Date().toISOString();
-
-  const n = user.notifications;
-  res.status(200).json({
-    message: "Notification settings updated successfully",
-    notifications: {
-      newInvitationReceived: n.newInvitationReceived ?? n.inviteReceived ?? true,
-      inviteAccepted:        n.inviteAccepted        ?? n.matchConfirmed ?? true,
-      sessionReminder:       n.sessionReminder       ?? true,
-      sessionBookingConfirmation: n.sessionBookingConfirmation ?? true,
-    },
-  });
 };
 
 module.exports = {

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -261,6 +261,23 @@ function AppRoutes({ initialIsAuthenticated = false }) {
 
   const navigate = useNavigate();
 
+  function clearLocalSession() {
+    localStorage.removeItem("token");
+    localStorage.removeItem("userId");
+    localStorage.removeItem("userEmail");
+    localStorage.removeItem("fullName");
+    localStorage.removeItem("sessionEmail");
+    localStorage.removeItem("sessionFullName");
+    localStorage.removeItem("pairup_profile_data");
+  }
+
+  function handleLogout() {
+    clearLocalSession();
+    setIsAuthenticated(false);
+    setIsOnboarding(false);
+    navigate("/login", { replace: true });
+  }
+
   const selectedPartnerIds = useMemo(
     () => new Set(partners.map((p) => p.id)),
     [partners]
@@ -496,7 +513,7 @@ function AppRoutes({ initialIsAuthenticated = false }) {
         path="/settings"
         element={
           <ProtectedRoute isAuthenticated={isAuthenticated}>
-            <SettingsPage />
+            <SettingsPage onLogout={handleLogout} />
           </ProtectedRoute>
         }
       />

--- a/front-end/src/components/OnboardingStepAvailability.css
+++ b/front-end/src/components/OnboardingStepAvailability.css
@@ -16,7 +16,7 @@
   min-height: 100dvh;
   background: #ffffff;
   border-radius: 0;
-  padding: 16px 16px 28px;
+  padding: 24px 16px 28px;
   box-shadow: none;
 }
 
@@ -29,12 +29,12 @@
 
 .onboarding-avail__back {
   flex-shrink: 0;
-  width: 40px;
-  height: 40px;
-  margin: -4px 0 0 -6px;
+  width: 32px;
+  height: 32px;
+  margin: -4px 0 0 -2px;
   border: none;
   background: transparent;
-  font-size: 1.75rem;
+  font-size: 1.5rem;
   line-height: 1;
   color: #0a2540;
   cursor: pointer;
@@ -317,6 +317,10 @@
   letter-spacing: 0.06em;
   color: #9ca3af;
   text-transform: uppercase;
+}
+
+.onboarding-avail__matches .onboarding-avail__fieldset + .onboarding-avail__fieldset {
+  margin-top: 18px;
 }
 
 .onboarding-avail__pill-row {

--- a/front-end/src/components/OnboardingStepLevel.css
+++ b/front-end/src/components/OnboardingStepLevel.css
@@ -16,7 +16,7 @@
   min-height: 100dvh;
   background: #ffffff;
   border-radius: 0;
-  padding: 16px 20px 28px;
+  padding: 24px 20px 28px;
   box-shadow: none;
 }
 
@@ -29,12 +29,12 @@
 
 .onboarding-level__back {
   flex-shrink: 0;
-  width: 40px;
-  height: 40px;
-  margin: -4px 0 0 -6px;
+  width: 32px;
+  height: 32px;
+  margin: -4px 0 0 -2px;
   border: none;
   background: transparent;
-  font-size: 1.75rem;
+  font-size: 1.5rem;
   line-height: 1;
   color: #0a2540;
   cursor: pointer;

--- a/front-end/src/components/PartnerSpaceScreen.css
+++ b/front-end/src/components/PartnerSpaceScreen.css
@@ -27,8 +27,8 @@
 .partner-space__top {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 8px 8px 10px 4px;
+  gap: 8px;
+  padding: 12px 14px;
   background: #fff;
   border-bottom: 1px solid #e5e7eb;
   flex-shrink: 0;
@@ -60,7 +60,7 @@
   flex: 1;
   border: none;
   background: transparent;
-  padding: 6px 8px;
+  padding: 8px 10px;
   margin: 0;
   border-radius: 12px;
   cursor: pointer;
@@ -110,8 +110,8 @@
 }
 
 .partner-space__upcoming-pill {
-  margin: 10px 12px 0;
-  padding: 8px 12px;
+  margin: 14px 16px 0;
+  padding: 10px 14px;
   border-radius: 999px;
   background: #dbeafe;
   color: #1e40af;
@@ -127,8 +127,8 @@
 }
 
 .partner-space__proposal-in {
-  margin: 12px 12px 0;
-  padding: 14px;
+  margin: 14px 16px 0;
+  padding: 16px;
   border-radius: 14px;
   background: #fff;
   border: 1px solid #e2e8f0;
@@ -184,8 +184,8 @@
 }
 
 .partner-space__banner {
-  margin: 10px 12px 0;
-  padding: 10px 12px;
+  margin: 12px 16px 0;
+  padding: 12px 14px;
   border-radius: 10px;
   background: #fef9c3;
   color: #854d0e;
@@ -210,10 +210,10 @@
   flex: 1;
   min-height: 120px;
   overflow-y: auto;
-  padding: 16px 12px 12px;
+  padding: 22px 16px 18px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
   background: #f9fafb;
 }
 
@@ -235,7 +235,7 @@
 
 .partner-space__row {
   display: flex;
-  gap: 8px;
+  gap: 10px;
   align-items: flex-end;
 }
 
@@ -274,10 +274,10 @@
 }
 
 .partner-space__bubble {
-  padding: 10px 12px;
+  padding: 12px 14px;
   border-radius: 14px;
   font-size: 0.875rem;
-  line-height: 1.4;
+  line-height: 1.5;
   word-wrap: break-word;
 }
 
@@ -305,8 +305,8 @@
 
 .partner-space__feedback {
   flex-shrink: 0;
-  margin: 0 12px 8px;
-  padding: 14px;
+  margin: 0 16px 12px;
+  padding: 16px;
   border-radius: 14px;
   background: #fff;
   border: 1px solid #e2e8f0;
@@ -510,7 +510,7 @@
 
 .partner-space__composer {
   flex-shrink: 0;
-  padding: 10px 12px 16px;
+  padding: 14px 16px 20px;
   background: #fff;
   border-top: 1px solid #e2e8f0;
 }
@@ -519,7 +519,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin-bottom: 10px;
+  margin-bottom: 12px;
   padding: 0;
   border: none;
   background: none;
@@ -550,13 +550,13 @@
 .partner-space__input-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
 }
 
 .partner-space__input {
   flex: 1;
   min-width: 0;
-  padding: 12px 14px;
+  padding: 13px 16px;
   border: 1px solid #e2e8f0;
   border-radius: 999px;
   font-size: 0.9375rem;
@@ -571,8 +571,8 @@
 }
 
 .partner-space__send {
-  width: 44px;
-  height: 44px;
+  width: 46px;
+  height: 46px;
   border: none;
   border-radius: 50%;
   background: #0d5c5f;

--- a/front-end/src/components/PartnerSpaceScreen.js
+++ b/front-end/src/components/PartnerSpaceScreen.js
@@ -1,6 +1,5 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { formatRelativeAgo } from '../utils/relativeTime';
-import { getPartnerSpaceDemo } from '../services/mockApi';
 import { DEFAULT_SCHEDULE_AVAILABILITY_SLOTS } from '../utils/scheduleCalendar';
 import ScheduleSessionSheet from './ScheduleSessionSheet';
 import './PartnerSpaceScreen.css';
@@ -32,10 +31,6 @@ function buildProposalSystemMessage(payload, partnerFirstName) {
   return `Proposal sent: ${payload.interviewType} (${payload.level}). ${partnerFirstName} will pick one of ${payload.slots.length} time option(s). Meeting link is included for your partner.`;
 }
 
-function feedbackDoneStorageKey(partnerId, sessionLabel) {
-  return `pairup-feedback-done-${partnerId}-${sessionLabel}`;
-}
-
 function PartnerSpaceScreen({
   partner,
   onBack,
@@ -43,9 +38,10 @@ function PartnerSpaceScreen({
   availabilitySlots = DEFAULT_SCHEDULE_AVAILABILITY_SLOTS,
   nowMs = Date.now(),
 }) {
-  const demo = useMemo(() => getPartnerSpaceDemo(partner.id), [partner.id]);
   const dialogTitleId = useId();
   const referenceDate = useMemo(() => new Date(nowMs), [nowMs]);
+  const introTimeline = partner.timeline || 'your prep timeline';
+  const icebreakerDraft = `Hey ${partner.name.split(' ')[0] || 'there'}! Want to prep together this week?`;
 
   const [disconnectOpen, setDisconnectOpen] = useState(false);
   const [scheduleOpen, setScheduleOpen] = useState(false);
@@ -91,9 +87,7 @@ function PartnerSpaceScreen({
 
     fetchProposals();
   }, [partner.id]);
-  const feedbackKey = demo.postSessionFeedback
-    ? feedbackDoneStorageKey(partner.id, demo.postSessionFeedback.sessionLabel)
-    : null;
+  const feedbackKey = null;
   const [feedbackDone, setFeedbackDone] = useState(false);
   const [fbStep, setFbStep] = useState(1);
   const [q1AckVisible, setQ1AckVisible] = useState(false);
@@ -147,10 +141,10 @@ function PartnerSpaceScreen({
           seedMessages.push({
             id: `sys-intro-${partner.id}`,
             kind: 'system',
-            body: buildSystemIntro(partner, demo.introTimeline),
+            body: buildSystemIntro(partner, introTimeline),
             at: Date.now(),
           });
-          setDraft(demo.icebreaker);
+          setDraft(icebreakerDraft);
         } else {
           setDraft('');
         }
@@ -214,7 +208,7 @@ function PartnerSpaceScreen({
 
     setHydrated(false);
     loadChatFromApi();
-  }, [partner, demo]);
+  }, [partner, introTimeline, icebreakerDraft]);
 
   useEffect(() => {
     if (!hydrated) return;
@@ -224,9 +218,9 @@ function PartnerSpaceScreen({
     }
   }, [messages, hydrated, feedbackDone, fbStep]);
 
-  const showFeedback = demo.postSessionFeedback && !feedbackDone;
+  const showFeedback = false;
 
-  const showOutgoingBanner = demo.outgoingProposalWaiting || localProposalSent;
+  const showOutgoingBanner = localProposalSent;
 
   const send = async () => {
     const text = draft.trim();
@@ -506,17 +500,17 @@ function PartnerSpaceScreen({
         <div ref={endRef} />
       </div>
 
-      {showFeedback && demo.postSessionFeedback && (
+      {showFeedback && (
         <div className="partner-space__feedback" role="region" aria-label="Session feedback">
           <div className="partner-space__feedback-head">
             <p className="partner-space__feedback-kicker">Session feedback</p>
-            <p className="partner-space__feedback-meta-right">{demo.postSessionFeedback.sessionLabel}</p>
+            <p className="partner-space__feedback-meta-right">Recent session</p>
           </div>
 
           {fbStep === 1 && !q1AckVisible && (
             <>
               <p className="partner-space__feedback-q">
-                Did {demo.postSessionFeedback.partnerFirstName} show up to the session?
+                Did {firstName} show up to the session?
               </p>
               <div className="partner-space__feedback-actions">
                 <button

--- a/front-end/src/components/PartnersList.css
+++ b/front-end/src/components/PartnersList.css
@@ -198,15 +198,15 @@
 
 .partners-list__empty-title {
   margin: 0 0 8px;
-  font-size: 2rem;
-  letter-spacing: -0.02em;
-  font-weight: 800;
+  font-size: 1.125rem;
+  letter-spacing: 0;
+  font-weight: 700;
   color: #0a2540;
 }
 
 .partners-list__empty-copy {
   margin: 0 0 20px;
-  font-size: 1.05rem;
+  font-size: 0.9375rem;
   line-height: 1.5;
   color: #6b7280;
 }
@@ -250,6 +250,6 @@
   }
 
   .partners-list__empty-title {
-    font-size: 1.95rem;
+    font-size: 1.125rem;
   }
 }

--- a/front-end/src/components/PartnersList.css
+++ b/front-end/src/components/PartnersList.css
@@ -1,8 +1,8 @@
 .partners-list {
   min-height: 100vh;
-  padding: 32px 20px 0;
+  padding: 28px 24px calc(96px + env(safe-area-inset-bottom));
   box-sizing: border-box;
-  background: #eef3f6;
+  background: linear-gradient(180deg, #f1f5f8 0%, #e9f0f5 100%);
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: #163042;
   display: flex;
@@ -10,27 +10,29 @@
 }
 
 .partners-list--empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 60vh;
+  justify-content: flex-start;
 }
 
 .partners-list__empty-inner {
-  max-width: 320px;
+  max-width: 520px;
+  margin: 56px auto 0;
+  padding: 0;
   text-align: center;
 }
 
 .partners-list__header {
-  margin-bottom: 16px;
+  margin: 0 auto 16px;
+  width: 100%;
+  max-width: 760px;
 }
 
 .partners-list__title {
   margin: 0;
-  font-size: 2.2rem;
+  font-size: 2.35rem;
   font-weight: 800;
   color: #0d2234;
-  letter-spacing: -0.02em;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
 }
 
 .partners-list__sub {
@@ -41,15 +43,13 @@
 
 .partners-list__ul {
   list-style: none;
-  margin: 0;
-  padding: 0 0 80px;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 760px;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 22px;
-}
-
-.partners-list > .bottom-nav {
-  margin-top: auto;
 }
 
 .partners-list__li {
@@ -197,15 +197,16 @@
 }
 
 .partners-list__empty-title {
-  margin: 12px 0 8px;
-  font-size: 1.125rem;
-  font-weight: 700;
+  margin: 0 0 8px;
+  font-size: 2rem;
+  letter-spacing: -0.02em;
+  font-weight: 800;
   color: #0a2540;
 }
 
 .partners-list__empty-copy {
   margin: 0 0 20px;
-  font-size: 0.9375rem;
+  font-size: 1.05rem;
   line-height: 1.5;
   color: #6b7280;
 }
@@ -232,4 +233,23 @@
 .partners-list__empty-cta:focus-visible {
   outline: 2px solid #2563eb;
   outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .partners-list {
+    padding: 24px 20px calc(96px + env(safe-area-inset-bottom));
+  }
+
+  .partners-list__title {
+    font-size: 2.05rem;
+  }
+
+  .partners-list__empty-inner {
+    margin-top: 40px;
+    padding: 24px 18px;
+  }
+
+  .partners-list__empty-title {
+    font-size: 1.95rem;
+  }
 }

--- a/front-end/src/components/PartnersList.js
+++ b/front-end/src/components/PartnersList.js
@@ -14,8 +14,10 @@ function PartnersList({ partners, onOpenPartner, onGoToMatches, nowMs = Date.now
   if (count === 0) {
     return (
       <div className="partners-list partners-list--empty">
-        <div className="partners-list__empty-inner">
+        <header className="partners-list__header">
           <h1 className="partners-list__title">Partners</h1>
+        </header>
+        <div className="partners-list__empty-inner">
           <h2 className="partners-list__empty-title">No active partnerships yet</h2>
           <p className="partners-list__empty-copy">
             Accept a match to start a prep partnership — you&apos;ll manage every ongoing relationship

--- a/front-end/src/components/button/BottomNav.css
+++ b/front-end/src/components/button/BottomNav.css
@@ -1,5 +1,5 @@
 .bottom-nav {
-  position: sticky;
+  position: fixed;
   bottom: 0;
   left: 0;
   width: 100%;
@@ -9,6 +9,7 @@
   border-top: 1px solid #d9e3ea;
   box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.04);
   z-index: 20;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .bottom-nav__item {

--- a/front-end/src/pages/ProfileEdit/ProfilePage.css
+++ b/front-end/src/pages/ProfileEdit/ProfilePage.css
@@ -1,6 +1,9 @@
 .profile-page {
   min-height: 100vh;
   width: 100%;
+  background: #eef3f6;
+  padding: 16px 16px calc(96px + env(safe-area-inset-bottom));
+  box-sizing: border-box;
 }
 
 .profile-card {

--- a/front-end/src/pages/ProfileEdit/ProfilePage.jsx
+++ b/front-end/src/pages/ProfileEdit/ProfilePage.jsx
@@ -184,7 +184,7 @@ function ProfilePage({ onBackToEdit, successMessage }) {
         </button>
       </div>
 
-      <BottomNav />
+      <BottomNav active="profile" />
     </div>
   );
 }

--- a/front-end/src/pages/matches/MatchesPage.css
+++ b/front-end/src/pages/matches/MatchesPage.css
@@ -2,8 +2,8 @@
 
 .matches-page {
   min-height: 100vh;
-  background: #eef3f6;
-  padding: 32px 20px 0;
+  background: linear-gradient(180deg, #f1f5f8 0%, #e9f0f5 100%);
+  padding: 28px 24px calc(96px + env(safe-area-inset-bottom));
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: #163042;
   display: flex;
@@ -12,14 +12,17 @@
 
 /* Header */
 .matches-page__header {
-  margin-bottom: 20px;
+  margin: 0 auto 20px;
+  width: 100%;
+  max-width: 760px;
 }
 
 .matches-page__title {
   margin: 0;
-  font-size: 2.2rem;
+  font-size: 2.35rem;
   font-weight: 800;
-  letter-spacing: -0.02em;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
   color: #0d2234;
 }
 
@@ -28,7 +31,9 @@
   display: flex;
   gap: 14px;
   flex-shrink: 0;
-  margin-bottom: 18px;
+  margin: 0 auto 18px;
+  width: 100%;
+  max-width: 760px;
 }
 
 .matches-page__tab {
@@ -73,6 +78,9 @@
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
 }
 
 .matches-page__panel[hidden] {
@@ -81,10 +89,10 @@
 
 @media (max-width: 768px) {
   .matches-page {
-    padding: 24px 14px 0;
+    padding: 24px 20px calc(96px + env(safe-area-inset-bottom));
   }
 
   .matches-page__title {
-    font-size: 1.9rem;
+    font-size: 2.05rem;
   }
 }

--- a/front-end/src/pages/settings/SettingsPage.jsx
+++ b/front-end/src/pages/settings/SettingsPage.jsx
@@ -51,7 +51,7 @@ function ExpandPanel({ open, children }) {
   return <div className="settings-expand">{children}</div>;
 }
 
-function SettingsPage() {
+function SettingsPage({ onLogout }) {
   const navigate = useNavigate();
   const { profile, updateField, saveProfile } = useProfile();
 
@@ -269,8 +269,12 @@ function SettingsPage() {
       }
 
       localStorage.removeItem("token");
+      localStorage.removeItem("userId");
       localStorage.removeItem("userEmail");
       localStorage.removeItem("fullName");
+      localStorage.removeItem("sessionEmail");
+      localStorage.removeItem("sessionFullName");
+      localStorage.removeItem("pairup_profile_data");
 
       setMessage("Account deleted.");
       navigate("/login");
@@ -339,6 +343,23 @@ function SettingsPage() {
       console.error("Notification update error:", error);
       setMessage("Server error.");
     }
+  }
+
+  function handleLogout() {
+    localStorage.removeItem("token");
+    localStorage.removeItem("userId");
+    localStorage.removeItem("userEmail");
+    localStorage.removeItem("fullName");
+    localStorage.removeItem("sessionEmail");
+    localStorage.removeItem("sessionFullName");
+    localStorage.removeItem("pairup_profile_data");
+
+    if (typeof onLogout === "function") {
+      onLogout();
+      return;
+    }
+
+    navigate("/login");
   }
 
   return (
@@ -473,6 +494,13 @@ function SettingsPage() {
               {loading ? "Deleting..." : "Delete account"}
             </button>
           </ExpandPanel>
+
+          <ChevronRow
+            title="Log out"
+            subtitle="Sign out of your PairUp account on this device"
+            danger
+            onClick={handleLogout}
+          />
         </section>
 
         <section className="settings-section">

--- a/front-end/src/services/mockApi.js
+++ b/front-end/src/services/mockApi.js
@@ -1,24 +1,9 @@
 /**
- * mockApi.js — simulated async service layer.
- *
- * Pages and components must NEVER import directly from src/data/.
- * All data access goes through this file so that swapping in a real API
- * later only requires changes here.
+ * Central frontend API service layer.
+ * Note: no local mock datasets are used here.
  */
 
-import { mockDiscoverUsers } from "../data/mockDiscoverUsers";
-import { mockUsers } from "../data/mockUsers";
-import { PARTNERS_MOCK_NOW, partnersMock } from "../data/partnersMock";
-import { getPartnerSpaceDemo as getPartnerSpaceDemoFromData } from "../data/partnerSpaceDemo";
-import mockProfile from "../data/mockProfile.json";
-import {
-  receivedInvitesMock,
-  sentInvitesMock,
-  matchRecommendationsMock,
-} from "../data/matchesMock.js";
-
-// Re-export for consumers that need the demo clock anchor (tests, app shell).
-export { PARTNERS_MOCK_NOW };
+export const PARTNERS_MOCK_NOW = Date.now();
 
 /** Dispatched after a friend invite is accepted so App can refetch GET /api/friends. */
 export const PARTNERS_REFRESH_EVENT = "pairup:partners-refresh";
@@ -55,6 +40,18 @@ function notifyPartnersRefresh() {
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent(PARTNERS_REFRESH_EVENT));
   }
+}
+
+async function requestJson(url, options = {}) {
+  const res = await fetch(url, {
+    ...options,
+    headers: withBearer(options.headers || {}),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(data.error || data.message || `HTTP ${res.status}`);
+  }
+  return data;
 }
 
 function initialsFromName(name) {
@@ -122,37 +119,31 @@ export function getInitialPartners() {
   return [];
 }
 
-/** Partner-space demo flags/messages; replace with GET /partners/:id/space. */
-export function getPartnerSpaceDemo(partnerId) {
-  return getPartnerSpaceDemoFromData(partnerId);
-}
-
-/** Seed row for default profile form; replace with GET /profile/me. */
+/** Seed row for default profile form (empty until profile API loads). */
 export function getDefaultProfileSeed() {
-  return mockProfile[0] ?? null;
+  return null;
 }
 
 // ── Discover ──────────────────────────────────────────────────────────────────
 
-export function fetchDiscoverUsers() {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(mockDiscoverUsers);
-    }, 250);
-  });
+export async function fetchDiscoverUsers() {
+  try {
+    const data = await requestJson(withAuthQuery("/api/matches"));
+    return data.matches || [];
+  } catch {
+    return [];
+  }
 }
 
 // ── User profile (view another user) ─────────────────────────────────────────
 
-function wait(ms = 220) {
-  return new Promise((res) => setTimeout(res, ms));
-}
-
-/** Replace with GET /users/:id */
 export async function fetchUserById(id) {
-  await wait(180);
-  const user = mockUsers.find((u) => u.id === Number(id));
-  return user ? { ...user } : null;
+  try {
+    const data = await requestJson(withAuthQuery(`/api/users/${id}`));
+    return data.user || null;
+  } catch {
+    return null;
+  }
 }
 
 // ── Matches ───────────────────────────────────────────────────────────────────
@@ -200,71 +191,74 @@ function mapFriendRequestToSentInviteCard(request, user) {
   };
 }
 
-/** Returns received invites: friend requests from the API when available, else demo match cards. */
 export async function getReceivedInvites() {
   try {
-    const res = await fetch("/api/friends/requests?box=incoming", {
-      headers: withBearer(),
-    });
-
-    if (!res.ok) throw new Error("incoming friend requests failed");
-
-    const data = await res.json();
+    const data = await requestJson("/api/friends/requests?box=incoming");
     const requests = data.requests || [];
-
     const cards = await Promise.all(
       requests.map(async (r) => {
         const user = await fetchLegacyUser(r.fromUserId);
         return mapFriendRequestToInviteCard(r, user);
       })
     );
-
     return cards.filter(Boolean);
   } catch {
-    await wait();
-    return [...receivedInvitesMock];
+    return [];
   }
 }
 
 /** Returns invites the current user has sent that are still pending. */
 export async function getSentInvites() {
   try {
-    const res = await fetch("/api/friends/requests?box=outgoing", {
-      headers: withBearer(),
-    });
-
-    if (!res.ok) throw new Error("outgoing friend requests failed");
-
-    const data = await res.json();
+    const data = await requestJson("/api/friends/requests?box=outgoing");
     const requests = data.requests || [];
-
     const cards = await Promise.all(
       requests.map(async (r) => {
         const user = await fetchLegacyUser(r.toUserId);
         return mapFriendRequestToSentInviteCard(r, user);
       })
     );
-
     return cards.filter(Boolean);
   } catch {
-    await wait();
-    return [...sentInvitesMock];
+    return [];
   }
 }
 
 /** Returns recommended users to invite (shown inline on the Waiting tab). */
 export async function getMatchRecommendations() {
-  await wait();
-  return [...matchRecommendationsMock];
+  try {
+    const [matchesData, outgoingData] = await Promise.all([
+      requestJson(withAuthQuery("/api/matches")),
+      requestJson("/api/friends/requests?box=outgoing"),
+    ]);
+
+    const blockedIds = new Set((outgoingData.requests || []).map((r) => r.toUserId));
+    return (matchesData.matches || [])
+      .filter((m) => {
+        const id = m.userId || m.id || m._id;
+        return id && !blockedIds.has(id);
+      })
+      .slice(0, 5)
+      .map((m) => {
+        const id = m.userId || m.id || m._id;
+        const name = m.displayName || m.name || "Someone";
+        return {
+          id,
+          name,
+          avatarSeed: String(id).replace(/[^a-zA-Z0-9]/g, "") || "match",
+          role: m.role ?? "—",
+          tier: m.targetTier ?? "—",
+          background: m.background ?? "—",
+          matchScore: m.matchPercent ?? 0,
+        };
+      });
+  } catch {
+    return [];
+  }
 }
 
-/** Accept a received invite by id (friend request UUID or demo recv-* id). */
+/** Accept a received invite by id. */
 export async function acceptInvite(id) {
-  if (String(id).startsWith("recv-")) {
-    await wait(400);
-    return { id, status: "accepted" };
-  }
-
   const res = await fetch(`/api/friends/requests/${id}`, {
     method: "PATCH",
     headers: withBearer({
@@ -284,11 +278,6 @@ export async function acceptInvite(id) {
 
 /** Decline a received invite by id. */
 export async function declineInvite(id) {
-  if (String(id).startsWith("recv-")) {
-    await wait(300);
-    return { id, status: "declined" };
-  }
-
   const res = await fetch(`/api/friends/requests/${id}`, {
     method: "PATCH",
     headers: withBearer({
@@ -307,14 +296,6 @@ export async function declineInvite(id) {
 
 /** Cancel a sent invite by id. */
 export async function cancelSentInvite(id) {
-  if (
-    String(id).startsWith("sent-") ||
-    String(id).startsWith("recv-")
-  ) {
-    await wait(300);
-    return { id, status: "cancelled" };
-  }
-
   const res = await fetch(`/api/friends/requests/${id}`, {
     method: "PATCH",
     headers: withBearer({

--- a/front-end/src/styles/discover.css
+++ b/front-end/src/styles/discover.css
@@ -1,7 +1,7 @@
 .discover-page {
   min-height: 100vh;
-  background: #eef3f6;
-  padding: 32px 20px 48px;
+  background: linear-gradient(180deg, #f1f5f8 0%, #e9f0f5 100%);
+  padding: 28px 24px calc(96px + env(safe-area-inset-bottom));
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: #163042;
 }
@@ -11,14 +11,16 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 16px;
-  margin-bottom: 20px;
+  margin: 0 auto 20px;
+  max-width: 760px;
 }
 
 .discover-title {
   margin: 0;
-  font-size: 2.2rem;
+  font-size: 2.35rem;
   font-weight: 800;
-  letter-spacing: -0.02em;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
   color: #0d2234;
 }
 
@@ -32,14 +34,15 @@
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  border: 2px solid #d7e3ea;
-  background: #f6fbfd;
+  border: 1.5px solid #d0dde6;
+  background: #f8fbfd;
   color: #314b5e;
   border-radius: 999px;
   padding: 14px 22px;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
+  box-shadow: 0 4px 12px rgba(18, 42, 58, 0.06);
 }
 
 .filter-icon {
@@ -51,7 +54,8 @@
   justify-content: space-between;
   align-items: center;
   gap: 14px;
-  margin-bottom: 18px;
+  margin: 0 auto 18px;
+  max-width: 760px;
   flex-wrap: wrap;
 }
 
@@ -79,7 +83,8 @@
 }
 
 .discover-debug-row {
-  margin-bottom: 16px;
+  margin: 0 auto 16px;
+  max-width: 760px;
 }
 
 .debug-toggle {
@@ -96,6 +101,8 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+  max-width: 760px;
+  margin: 0 auto;
 }
 
 .discover-card {
@@ -333,11 +340,11 @@
 
 @media (max-width: 768px) {
   .discover-page {
-    padding: 24px 14px 40px;
+    padding: 24px 20px calc(96px + env(safe-area-inset-bottom));
   }
 
   .discover-title {
-    font-size: 1.9rem;
+    font-size: 2.05rem;
   }
 
   .discover-card {


### PR DESCRIPTION
# Remove Remaining Mock Behaviors and Polish UI/UX Design

## Summary
This PR removed the remaining mock-data-driven frontend behaviors and made some UI/UX design polishment, getting ready for Spint 4 deployment.

## Changes
1. Removed mock-data-driven frontend behavior and route data flows through backend API endpoints (`/api/matches`, `/api/friends`, `/api/friends/requests`, `/api/users/:id`).
2. Migrated settings notification reads/writes to MongoDB in `settingsController` instead of in-memory user data.
3. Improved resilience for Discover/Matches/Waiting flows by handling API/auth failures gracefully (return empty states instead of crashing).
4. Added logout UX from Settings and apply UI polish updates across Discover, onboarding, partner space, matches, and profile pages.

## Testing
1. Tested the application locally, everything is reflected in the current version and no error was found.

## To-Do
1. Test with two accounts for interactive behaviors