### PR TITLE
Polish navigation and profile metrics UX across settings and discover flows

### DIFF
--- a/front-end/src/components/OnboardingStepAvailability.css
+++ b/front-end/src/components/OnboardingStepAvailability.css
@@ -29,24 +29,37 @@
 
 .onboarding-avail__back {
   flex-shrink: 0;
-  width: 32px;
-  height: 32px;
+  width: 34px;
+  height: 34px;
   margin: -4px 0 0 -2px;
   border: none;
   background: transparent;
-  font-size: 1.5rem;
-  line-height: 1;
-  color: #0a2540;
+  color: #2f343a;
   cursor: pointer;
-  border-radius: 10px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.15s ease;
+  padding: 0;
+  line-height: 1;
+  transition: opacity 0.15s ease, transform 0.12s ease;
+}
+
+.onboarding-avail__back-icon {
+  width: 28px;
+  height: 28px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .onboarding-avail__back:hover {
-  background: #f3f4f6;
+  opacity: 0.75;
+}
+
+.onboarding-avail__back:active {
+  transform: scale(0.97);
 }
 
 .onboarding-avail__back:focus-visible {

--- a/front-end/src/components/OnboardingStepAvailability.js
+++ b/front-end/src/components/OnboardingStepAvailability.js
@@ -154,7 +154,9 @@ function OnboardingStepAvailability({ initialValues, onBack, onComplete }) {
             onClick={handleBack}
             aria-label="Back to previous step"
           >
-            <span aria-hidden="true">‹</span>
+            <svg className="onboarding-avail__back-icon" aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="M15 6L9 12L15 18" />
+            </svg>
           </button>
           <div className="onboarding-avail__progress-wrap">
             <div className="onboarding-avail__progress-bar" role="presentation">

--- a/front-end/src/components/OnboardingStepLevel.css
+++ b/front-end/src/components/OnboardingStepLevel.css
@@ -29,24 +29,37 @@
 
 .onboarding-level__back {
   flex-shrink: 0;
-  width: 32px;
-  height: 32px;
+  width: 34px;
+  height: 34px;
   margin: -4px 0 0 -2px;
   border: none;
   background: transparent;
-  font-size: 1.5rem;
-  line-height: 1;
-  color: #0a2540;
+  color: #2f343a;
   cursor: pointer;
-  border-radius: 10px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.15s ease;
+  padding: 0;
+  line-height: 1;
+  transition: opacity 0.15s ease, transform 0.12s ease;
+}
+
+.onboarding-level__back-icon {
+  width: 28px;
+  height: 28px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .onboarding-level__back:hover {
-  background: #f3f4f6;
+  opacity: 0.75;
+}
+
+.onboarding-level__back:active {
+  transform: scale(0.97);
 }
 
 .onboarding-level__back:focus-visible {

--- a/front-end/src/components/OnboardingStepLevel.js
+++ b/front-end/src/components/OnboardingStepLevel.js
@@ -107,7 +107,9 @@ function OnboardingStepLevel({ stepOneData, initialValues, onBack, onNext }) {
             onClick={handleBack}
             aria-label="Back to previous step"
           >
-            <span aria-hidden="true">‹</span>
+            <svg className="onboarding-level__back-icon" aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="M15 6L9 12L15 18" />
+            </svg>
           </button>
           <div className="onboarding-level__progress-wrap">
             <div className="onboarding-level__progress-bar" role="presentation">

--- a/front-end/src/components/PartnerSpaceScreen.css
+++ b/front-end/src/components/PartnerSpaceScreen.css
@@ -36,20 +36,42 @@
 }
 
 .partner-space__back {
-  width: 44px;
-  height: 44px;
+  width: 34px;
+  height: 34px;
   border: none;
   background: transparent;
-  font-size: 1.75rem;
+  padding: 0;
   line-height: 1;
-  color: #0f172a;
+  color: #2f343a;
   cursor: pointer;
-  border-radius: 10px;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s ease, transform 0.12s ease;
+}
+
+.partner-space__back-icon {
+  width: 28px;
+  height: 28px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .partner-space__back:hover {
-  background: #f1f5f9;
+  opacity: 0.75;
+}
+
+.partner-space__back:active {
+  transform: scale(0.97);
+}
+
+.partner-space__back:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 
 .partner-space__identity {

--- a/front-end/src/components/PartnerSpaceScreen.js
+++ b/front-end/src/components/PartnerSpaceScreen.js
@@ -374,7 +374,9 @@ function PartnerSpaceScreen({
         <div className="partner-space__card app-shell__card app-shell__card--fill">
       <header className="partner-space__top">
         <button type="button" className="partner-space__back" onClick={onBack} aria-label="Back to partners">
-          ‹
+          <svg className="partner-space__back-icon" aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M15 6L9 12L15 18" />
+          </svg>
         </button>
         <button
           type="button"

--- a/front-end/src/components/button/BottomNav.css
+++ b/front-end/src/components/button/BottomNav.css
@@ -31,8 +31,24 @@
 }
 
 .bottom-nav__icon {
-  font-size: 22px;
+  width: 24px;
+  height: 24px;
   line-height: 1;
+}
+
+.bottom-nav__icon svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.bottom-nav__icon-fill {
+  fill: currentColor;
+  stroke: none;
 }
 
 .bottom-nav__label {

--- a/front-end/src/components/button/BottomNav.jsx
+++ b/front-end/src/components/button/BottomNav.jsx
@@ -1,14 +1,55 @@
 import { useNavigate } from 'react-router-dom';
 import './BottomNav.css';
 
+function NavIcon({ type }) {
+  if (type === 'discover') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="12" cy="12" r="8" />
+        <circle cx="12" cy="12" r="3.5" className="bottom-nav__icon-fill" />
+      </svg>
+    );
+  }
+
+  if (type === 'matches') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="9.2" cy="12" r="4.4" />
+        <circle cx="14.8" cy="12" r="4.4" />
+        <path d="M11.3 9.6L12.7 9.6" />
+        <path d="M11.3 12L12.7 12" />
+        <path d="M11.3 14.4L12.7 14.4" />
+      </svg>
+    );
+  }
+
+  if (type === 'partner') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="9" cy="9" r="3" />
+        <circle cx="15.5" cy="10" r="2.5" />
+        <path d="M4.5 18C5 15.7 6.8 14.5 9 14.5C11.2 14.5 13 15.7 13.5 18" />
+        <path d="M12.8 18C13.2 16.2 14.6 15.2 16.2 15.2C17.8 15.2 19.1 16.1 19.5 17.8" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="8.3" r="3.2" />
+      <path d="M5.5 18.5C6.3 15.7 8.6 14.3 12 14.3C15.4 14.3 17.7 15.7 18.5 18.5" />
+    </svg>
+  );
+}
+
 function BottomNav({ active = 'discover' }) {
   const navigate = useNavigate();
 
   const items = [
-    { key: 'discover', label: 'Discover', path: '/discover', icon: '◉' },
-    { key: 'matches', label: 'Matches', path: '/matches', icon: '▢' },
-    { key: 'partner', label: 'Partner', path: '/partners', icon: '◎' },
-    { key: 'profile', label: 'Profile', path: '/profile/me', icon: '○' },
+    { key: 'discover', label: 'Discover', path: '/discover' },
+    { key: 'matches', label: 'Matches', path: '/matches' },
+    { key: 'partner', label: 'Partners', path: '/partners' },
+    { key: 'profile', label: 'Profile', path: '/profile/me' },
   ];
 
   return (
@@ -19,7 +60,9 @@ function BottomNav({ active = 'discover' }) {
           className={`bottom-nav__item ${active === item.key ? 'bottom-nav__item--active' : ''}`}
           onClick={() => navigate(item.path)}
         >
-          <div className="bottom-nav__icon">{item.icon}</div>
+          <div className="bottom-nav__icon">
+            <NavIcon type={item.key} />
+          </div>
           <div className="bottom-nav__label">{item.label}</div>
         </button>
       ))}

--- a/front-end/src/components/discover/DiscoverCard.jsx
+++ b/front-end/src/components/discover/DiscoverCard.jsx
@@ -61,7 +61,7 @@ function DiscoverCard({ user, onSendInvite, onViewProfile }) {
 
         <button
           className="secondary-btn"
-          onClick={() => onViewProfile(user.userId)}
+          onClick={() => onViewProfile(user)}
         >
           View profile
         </button>

--- a/front-end/src/components/profile/ProfileHero.jsx
+++ b/front-end/src/components/profile/ProfileHero.jsx
@@ -3,10 +3,14 @@ function ProfileHero({ user, onBack }) {
     <div className="profile-hero">
       <div className="profile-hero__topbar">
         <button className="profile-back-btn" onClick={onBack}>
-          ← Discover
+          <svg className="profile-back-btn__icon" aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M15 6L9 12L15 18" />
+          </svg>
         </button>
 
-        <span className="profile-match-badge">{user.matchPercentage}% match</span>
+        <span className="profile-match-badge">
+          {typeof user.matchPercentage === "number" ? `${user.matchPercentage}%` : "N/A"} match
+        </span>
       </div>
 
       <div className="profile-hero__main">

--- a/front-end/src/pages/DiscoverPage.jsx
+++ b/front-end/src/pages/DiscoverPage.jsx
@@ -37,8 +37,17 @@ function DiscoverPage() {
       });
   }, []);
 
-  function handleViewProfile(userId) {
-    navigate(`/profile/${userId}`);
+  function handleViewProfile(user) {
+    const targetId = user.userId || user.id || user._id;
+    navigate(`/profile/${targetId}`, {
+      state: {
+        metrics: {
+          matchPercent: user.matchPercent,
+          sessionsCompleted: user.sessionsCompleted,
+          showUpRate: user.showUpRate,
+        },
+      },
+    });
   }
 
   async function handleSendInvite(targetUserId) {

--- a/front-end/src/pages/UserProfilePage.jsx
+++ b/front-end/src/pages/UserProfilePage.jsx
@@ -8,9 +8,19 @@ import AvailabilityGrid from "../components/profile/AvailabilityGrid";
 import SessionPreferencesSection from "../components/profile/SessionPreferencesSection";
 import StickyInviteBar from "../components/profile/StickyInviteBar";
 import "../styles/profile.css";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 
-function mapApiUserToProfile(apiUser) {
+function toPercentValue(value) {
+  if (typeof value !== "number" || Number.isNaN(value)) return null;
+  const normalized = value <= 1 ? value * 100 : value;
+  return Math.round(normalized);
+}
+
+function mapApiUserToProfile(apiUser, metrics = {}) {
+  const showUpRateFromMetrics = toPercentValue(metrics.showUpRate);
+  const showUpRateFromApi = toPercentValue(apiUser.showUpRate);
+  const matchPercentage = toPercentValue(metrics.matchPercent);
+
   return {
     ...apiUser,
 
@@ -23,7 +33,7 @@ function mapApiUserToProfile(apiUser) {
 
     name: apiUser.displayName,
     linkedin: apiUser.linkedinUrl,
-    matchPercentage: null,
+    matchPercentage,
 
     goal: {
       role: apiUser.role,
@@ -65,8 +75,11 @@ function mapApiUserToProfile(apiUser) {
       notes: apiUser.feedbackStyle,
     },
 
-    completedSessions: apiUser.sessionsCompleted,
-    showUpRate: apiUser.showUpRate,
+    completedSessions:
+      typeof metrics.sessionsCompleted === "number"
+        ? metrics.sessionsCompleted
+        : apiUser.sessionsCompleted,
+    showUpRate: showUpRateFromMetrics ?? showUpRateFromApi ?? 100,
     invited: false,
   };
 }
@@ -76,6 +89,7 @@ function UserProfilePage() {
   const [loading, setLoading] = useState(true);
   const [selectedTimezone, setSelectedTimezone] = useState("ET");
   const { id } = useParams();
+  const location = useLocation();
 
   useEffect(() => {
     let cancelled = false;
@@ -91,7 +105,8 @@ function UserProfilePage() {
       })
       .then((data) => {
         if (!cancelled) {
-          setUser(mapApiUserToProfile(data.user));
+          const navMetrics = location.state?.metrics || {};
+          setUser(mapApiUserToProfile(data.user, navMetrics));
           setLoading(false);
         }
       })
@@ -105,7 +120,7 @@ function UserProfilePage() {
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [id, location.state]);
 
   function handleInvite() {
     setUser((prev) => (prev ? { ...prev, invited: true } : null));

--- a/front-end/src/pages/settings/SettingsPage.css
+++ b/front-end/src/pages/settings/SettingsPage.css
@@ -19,27 +19,55 @@
   height: 74px;
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 8px;
   padding: 0 18px;
   background: #ffffff;
   border-bottom: 1px solid #d7e1e8;
 }
 
 .settings-back {
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: none;
   background: transparent;
-  font-size: 28px;
-  color: #5f7487;
+  color: #2f343a;
   cursor: pointer;
   padding: 0;
   line-height: 1;
+  transition: opacity 0.15s ease, transform 0.12s ease;
+}
+
+.settings-back-icon {
+  width: 28px;
+  height: 28px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.settings-back:hover {
+  opacity: 0.75;
+}
+
+.settings-back:active {
+  transform: scale(0.97);
+}
+
+.settings-back:focus-visible {
+  outline: 2px solid #156b8f;
+  outline-offset: 2px;
 }
 
 .settings-title {
   margin: 0;
   font-size: 28px;
   font-weight: 700;
-  color: #10253d;
+  color: #2f343a;
 }
 
 .settings-section {

--- a/front-end/src/pages/settings/SettingsPage.jsx
+++ b/front-end/src/pages/settings/SettingsPage.jsx
@@ -370,8 +370,16 @@ function SettingsPage({ onLogout }) {
             className="settings-back"
             type="button"
             onClick={() => navigate(-1)}
+            aria-label="Go back"
           >
-            ←
+            <svg
+              className="settings-back-icon"
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              focusable="false"
+            >
+              <path d="M15 6L9 12L15 18" />
+            </svg>
           </button>
           <h1 className="settings-title">Settings</h1>
         </header>

--- a/front-end/src/styles/profile.css
+++ b/front-end/src/styles/profile.css
@@ -29,10 +29,24 @@
 .profile-back-btn {
   border: none;
   background: transparent;
-  color: #3f6275;
-  font-weight: 600;
+  color: #2f343a;
   cursor: pointer;
-  font-size: 0.95rem;
+  font-size: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  line-height: 1;
+}
+
+.profile-back-btn__icon {
+  width: 24px;
+  height: 24px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
 }
 
 .profile-match-badge {


### PR DESCRIPTION
# Polish navigation and profile metrics UX across settings and discover flows

## Summary
This PR made some polishement to the navigation bar, back-button, and fixed the profile metrics reflected on the detailed profile page.

## Changes
1. Standardized back-button styling across key screens (settings, profile, onboarding, and partner space) to a cleaner chevron-based design.
2. Updated bottom navigation semantics and visuals
3. Fixed profile metric accuracy when navigating from Discover

## Testing
1. Ran the frontend locally. Every change correctly appears.