### PR TITLE
Fix delete account flow

### DIFF
--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -271,11 +271,11 @@ function AppRoutes({ initialIsAuthenticated = false }) {
     localStorage.removeItem("pairup_profile_data");
   }
 
-  function handleLogout() {
+  function handleLogout({ redirectState } = {}) {
     clearLocalSession();
     setIsAuthenticated(false);
     setIsOnboarding(false);
-    navigate("/login", { replace: true });
+    navigate("/login", { replace: true, state: redirectState });
   }
 
   const selectedPartnerIds = useMemo(

--- a/front-end/src/pages/auth/Auth.css
+++ b/front-end/src/pages/auth/Auth.css
@@ -164,6 +164,16 @@
   margin-top: -4px;
 }
 
+.auth-success-text {
+  color: #166534;
+  background: #dcfce7;
+  border: 1px solid #86efac;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 13px;
+  margin: -4px 0 6px;
+}
+
 .auth-success {
   text-align: center;
   margin-top: 220px;

--- a/front-end/src/pages/auth/LoginPage.jsx
+++ b/front-end/src/pages/auth/LoginPage.jsx
@@ -1,11 +1,16 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { Users } from "lucide-react";
 import "./Auth.css";
 
 const API_BASE = "http://localhost:3000";
 
 function LoginPage({ onLoginSuccess }) {
+  const location = useLocation();
+  const accountDeletedMessage =
+    location.state?.accountDeleted && location.state?.message
+      ? location.state.message
+      : "";
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -123,6 +128,9 @@ function LoginPage({ onLoginSuccess }) {
         ) : (
           <form onSubmit={handleSubmit} className="auth-form">
             <h2>{forgot ? "Reset your password" : "Welcome back"}</h2>
+            {accountDeletedMessage ? (
+              <p className="auth-success-text">{accountDeletedMessage}</p>
+            ) : null}
 
             <label>Email</label>
             <input

--- a/front-end/src/pages/settings/SettingsPage.jsx
+++ b/front-end/src/pages/settings/SettingsPage.jsx
@@ -277,7 +277,24 @@ function SettingsPage({ onLogout }) {
       localStorage.removeItem("pairup_profile_data");
 
       setMessage("Account deleted.");
-      navigate("/login");
+
+      if (typeof onLogout === "function") {
+        onLogout({
+          redirectState: {
+            accountDeleted: true,
+            message: "Account deleted successfully.",
+          },
+        });
+        return;
+      }
+
+      navigate("/login", {
+        replace: true,
+        state: {
+          accountDeleted: true,
+          message: "Account deleted successfully.",
+        },
+      });
     } catch (error) {
       console.error("Delete account error:", error);
       setMessage("Server error.");


### PR DESCRIPTION
# Fix Account Deletion Flow

## Summary
This PR fixes an issue where, after a user clicked Delete Account, the account was deleted successfully, but the user stayed on the current page instead of being redirected back to the login page.

## Testing
1. Tested locally by creating several live account and tried to delete them. The accounts were correctly deleted and the users were correctly redirected.