### PR TITLE
Auto-redirect to login when JWT expires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,14 +128,5 @@ typings/
 **/.jekyll-cache
 **/_site/
 
-# Claude / AI tooling — local only, never push
-# .claude/
-# **/.claude/
-# .claude*
-# CLAUDE.md
-# **/CLAUDE.md
-# PROGRESS.md
-# **/PROGRESS.md
-# RYAN-INSTRUCTIONS.md
-# **/RYAN-INSTRUCTIONS.md
-# docs/superpowers/
+# local environment fix
+dnsfix.local.js

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -305,9 +305,11 @@ function AppRoutes({ initialIsAuthenticated = false }) {
     clearLocalSession();
     setIsAuthenticated(false);
     setIsOnboarding(false);
-    navigate("/login", { replace: true, state: redirectState });
+    const search =
+      redirectState?.reason === "session-expired" ? "?session-expired=1" : "";
+    navigate(`/login${search}`, { replace: true, state: redirectState });
   }
-
+  
   const selectedPartnerIds = useMemo(
     () => new Set(partners.map((p) => p.id)),
     [partners]
@@ -328,7 +330,6 @@ function AppRoutes({ initialIsAuthenticated = false }) {
     return () => window.removeEventListener(PARTNERS_REFRESH_EVENT, mergeFriendsFromApi);
   }, [isAuthenticated]);
 
-  // ←←← PASTE THE NEW useEffect HERE ←←←
   useEffect(() => {
     function onAuthExpired() {
       handleLogout({ redirectState: { reason: "session-expired" } });

--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -27,7 +27,7 @@ import EditProfileForm from "./pages/ProfileEdit/EditProfileForm";
 
 import MatchesPage from "./pages/matches/MatchesPage";
 
-import { PARTNERS_MOCK_NOW, PARTNERS_REFRESH_EVENT, fetchPartnersFromFriendsApi, getAuthHeaders, getInitialPartners, mergePartnerRows } from "./services/mockApi";
+import { AUTH_EXPIRED_EVENT, PARTNERS_MOCK_NOW, PARTNERS_REFRESH_EVENT, fetchPartnersFromFriendsApi, getAuthHeaders, getInitialPartners, mergePartnerRows } from "./services/mockApi";
 import { useProfile } from "./context/ProfileContext";
 import { API_BASE_URL } from "./config/apiBase";
 
@@ -200,6 +200,34 @@ function buildUserPayload(stepOne, stepTwo, stepThree) {
 }
 
 // ---------------------------------------------------------------------------
+// Auth helpers (module-scope so the useState initializer can call them)
+// ---------------------------------------------------------------------------
+function clearLocalSessionSync() {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem("token");
+  localStorage.removeItem("userId");
+  localStorage.removeItem("userEmail");
+  localStorage.removeItem("fullName");
+  localStorage.removeItem("sessionEmail");
+  localStorage.removeItem("sessionFullName");
+  localStorage.removeItem("pairup_profile_data");
+}
+
+function decodeJwtExp(token) {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const padded = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const json = atob(padded);
+    const data = JSON.parse(json);
+    return typeof data.exp === "number" ? data.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+
+// ---------------------------------------------------------------------------
 // Route guards
 // ---------------------------------------------------------------------------
 
@@ -248,7 +276,14 @@ function AppRoutes({ initialIsAuthenticated = false }) {
   const [isAuthenticated, setIsAuthenticated] = useState(() => {
     if (initialIsAuthenticated) return true;
     if (typeof window === "undefined") return false;
-    return Boolean(localStorage.getItem("token"));
+    const token = localStorage.getItem("token");
+    if (!token) return false;
+    const exp = decodeJwtExp(token);
+    if (exp && exp * 1000 < Date.now()) {
+      clearLocalSessionSync();
+      return false;
+    }
+    return true;
   });
   const [isOnboarding, setIsOnboarding] = useState(false);
   const { refetchProfile } = useProfile();
@@ -263,13 +298,7 @@ function AppRoutes({ initialIsAuthenticated = false }) {
   const navigate = useNavigate();
 
   function clearLocalSession() {
-    localStorage.removeItem("token");
-    localStorage.removeItem("userId");
-    localStorage.removeItem("userEmail");
-    localStorage.removeItem("fullName");
-    localStorage.removeItem("sessionEmail");
-    localStorage.removeItem("sessionFullName");
-    localStorage.removeItem("pairup_profile_data");
+    clearLocalSessionSync();
   }
 
   function handleLogout({ redirectState } = {}) {
@@ -283,7 +312,7 @@ function AppRoutes({ initialIsAuthenticated = false }) {
     () => new Set(partners.map((p) => p.id)),
     [partners]
   );
-
+  
   // Teammate: merge friends/chat data when authenticated
   useEffect(() => {
     if (!isAuthenticated) return undefined;
@@ -298,6 +327,16 @@ function AppRoutes({ initialIsAuthenticated = false }) {
     window.addEventListener(PARTNERS_REFRESH_EVENT, mergeFriendsFromApi);
     return () => window.removeEventListener(PARTNERS_REFRESH_EVENT, mergeFriendsFromApi);
   }, [isAuthenticated]);
+
+  // ←←← PASTE THE NEW useEffect HERE ←←←
+  useEffect(() => {
+    function onAuthExpired() {
+      handleLogout({ redirectState: { reason: "session-expired" } });
+    }
+    window.addEventListener(AUTH_EXPIRED_EVENT, onAuthExpired);
+    return () => window.removeEventListener(AUTH_EXPIRED_EVENT, onAuthExpired);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /**
    * Called when the user finishes the last onboarding step.

--- a/front-end/src/pages/auth/LoginPage.jsx
+++ b/front-end/src/pages/auth/LoginPage.jsx
@@ -11,6 +11,12 @@ function LoginPage({ onLoginSuccess }) {
     location.state?.accountDeleted && location.state?.message
       ? location.state.message
       : "";
+  
+  //add a message for when the session expires
+  const sessionExpiredMessage =
+    location.state?.reason === "session-expired"
+      ? "Your session expired. Please sign in again."
+      : "";
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -130,6 +136,9 @@ function LoginPage({ onLoginSuccess }) {
             <h2>{forgot ? "Reset your password" : "Welcome back"}</h2>
             {accountDeletedMessage ? (
               <p className="auth-success-text">{accountDeletedMessage}</p>
+            ) : null}
+            {sessionExpiredMessage ? (
+              <p className="auth-success-text">{sessionExpiredMessage}</p>
             ) : null}
 
             <label>Email</label>

--- a/front-end/src/pages/auth/LoginPage.jsx
+++ b/front-end/src/pages/auth/LoginPage.jsx
@@ -12,11 +12,11 @@ function LoginPage({ onLoginSuccess }) {
       ? location.state.message
       : "";
   
-  //add a message for when the session expires
-  const sessionExpiredMessage =
-    location.state?.reason === "session-expired"
-      ? "Your session expired. Please sign in again."
-      : "";
+  //add a message when the session expires
+  // add a message when the session expires (carried via URL search param)
+  const sessionExpiredMessage = location.search.includes("session-expired=1")
+    ? "Your session expired. Please sign in again."
+    : "";
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/front-end/src/services/mockApi.js
+++ b/front-end/src/services/mockApi.js
@@ -7,6 +7,8 @@ export const PARTNERS_MOCK_NOW = Date.now();
 
 /** Dispatched after a friend invite is accepted so App can refetch GET /api/friends. */
 export const PARTNERS_REFRESH_EVENT = "pairup:partners-refresh";
+export const AUTH_EXPIRED_EVENT = "pairup:auth-expired";
+let authExpiryNotified = false;
 
 function getStoredUserId() {
   if (typeof window === "undefined") return "current-user";
@@ -52,6 +54,13 @@ async function requestJson(url, options = {}) {
     headers: withBearer(options.headers || {}),
   });
   const data = await res.json().catch(() => ({}));
+  if (res.status === 401) {
+    if (!authExpiryNotified && typeof window !== "undefined") {
+      authExpiryNotified = true;
+      window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT));
+    }
+    throw new Error(data.error || data.message || "Unauthorized");
+  }
   if (!res.ok) {
     throw new Error(data.error || data.message || `HTTP ${res.status}`);
   }
@@ -92,7 +101,8 @@ async function fetchLegacyUser(userId) {
 
     const data = await res.json();
     return data.user || null;
-  } catch {
+  } catch (err) {
+    console.warn("fetchLegacyUser:", err.message);
     return null;
   }
 }
@@ -108,7 +118,8 @@ export async function fetchPartnersFromFriendsApi() {
 
     const data = await res.json();
     return (data.friends || []).map(apiFriendToPartnerRow);
-  } catch {
+  } catch (err) {
+    console.warn("fetchPartnersFromFriendsApi:", err.message);
     return [];
   }
 }
@@ -139,7 +150,8 @@ export async function fetchDiscoverRandomUsers() {
       cache: "no-store",
     });
     return data.matches || [];
-  } catch {
+  } catch (err) {
+    console.warn("fetchDiscoverRandomUsers:", err.message);
     return [];
   }
 }
@@ -153,7 +165,8 @@ export async function fetchDiscoverBestMatches() {
       cache: "no-store",
     });
     return data.matches || [];
-  } catch {
+  } catch (err) {
+    console.warn("fetchDiscoverBestMatches:", err.message);
     return [];
   }
 }
@@ -164,7 +177,8 @@ export async function fetchUserById(id) {
   try {
     const data = await requestJson(withAuthQuery(`/api/users/${id}`));
     return data.user || null;
-  } catch {
+  } catch (err) {
+    console.warn("fetchUserById:", err.message);
     return null;
   }
 }


### PR DESCRIPTION
Fixes a bug where an expired JWT silently broke Discove: the frontend kept sending the stale token, the backend returned 401, and the API layer swallowed every error — so users sat on an empty Discover with no clue their session had ended.

This PR makes expiry recoverable:

- API layer detects 401s and dispatches an auth-expired event; other silent catches now log to the console.

- App.js decodes the JWT at mount and clears expired tokens before rendering protected routes; it also listens for the 401 event and triggers logout mid-session.

- LoginPage shows a "Your session expired" banner when the redirect was due to expiry. The signal travels via ?session-expired=1 in the URL (router history state kept getting clobbered by the auth-state navigation race).